### PR TITLE
Small bugfix to function declaration in SymKey.js

### DIFF
--- a/source/SymKey.js
+++ b/source/SymKey.js
@@ -50,7 +50,7 @@ if(enyo.platform.webos && enyo.platform.webos < 3) {
 			this.sendFakeKey("keypress", charCode);
 			this.sendFakeKey("keyup", charCode);
 		},
-		sendFakeKey(eventType, charCode) {
+		sendFakeKey: function(eventType, charCode) {
 			var e = document.createEvent("Events");
 			e.initEvent(type, true, true);
 


### PR DESCRIPTION
sendFakeKey() does not count as a function declaration :)
sendFakeKey: function () does work
