### PR TITLE
Include Back identifier and send along event

### DIFF
--- a/source/BackGesture.js
+++ b/source/BackGesture.js
@@ -1,15 +1,18 @@
 /**
 	
-	Add an event listener for keyup to document to listen for the custom "U+1200001" key on OwOS
-	or for the ESC key (U+001B) on other platforms and call onbackbutton to be compatible with
-	PhoneGap
+	Add an event listener for keyup to document to listen for the custom "U+1200001" key on OwOS,
+	"Back" key on webOS 2.x or for the ESC key (U+001B) on other platforms and call onbackbutton
+	to be compatible with PhoneGap.
+
+	When handling the onbackbutton event, inEvent.stopPropagation() and/or inEvent.preventDefault()
+	are supported to stop the default behavior.
 	
 */
 
 (function() {
 	enyo.dispatcher.listen(document, 'keyup', function(ev) {
-		if (ev.keyIdentifier == "U+1200001" || ev.keyIdentifier == "U+001B") {
-			enyo.Signals.send('onbackbutton');
+		if (ev.keyIdentifier == "U+1200001" || ev.keyIdentifier == "U+001B" || ev.keyIdentifier == "Back") {
+			enyo.Signals.send('onbackbutton', ev);
 		}
 	});
-})()
+})();

--- a/source/ServiceRequest.js
+++ b/source/ServiceRequest.js
@@ -22,7 +22,7 @@ enyo.kind({
 		Properties passed in the inParams object will be mixed into the object itself,
 		so you can optionally set properties like _"service"_ and _"method"_ inline in the
 		constructor rather than using the setters individually.
-	*.
+	*/
 	constructor: function(inParams) {
 		enyo.mixin(this, inParams);
 		this.inherited(arguments);


### PR DESCRIPTION
Older webOS versions use the Back keyIdentifier which was missed
before. The key event is send along so any event handler can use
stopPropagation and preventDefault functions of the event object.

I tested on a Pre3 which indeed used the "Back" keyIdentifier. Alternatively, keyCode could be used instead of keyIdentifier. Both ESC on desktops as the "Back" event use keyCode 27. I decided to stay in line with the use of a keyIdentifier.

The change to ServiceRequest is just a fixed typo which trips a browser.
