### PR TITLE
fixes to clipboad handling

### DIFF
--- a/source/webos.js
+++ b/source/webos.js
@@ -298,11 +298,11 @@ webos = {
 		}
 		this._clipboardTextArea.value = inText;
 		document.body.appendChild(this._clipboardTextArea);
-		enyo.webos.setManualMode(true); //suspend keyboard
+		enyo.webos.keyboard.setManualMode(true); //suspend keyboard
 		this._clipboardTextArea.select();
 		document.execCommand("cut");
 		this._clipboardTextArea.blur();
-		enyo.webos.setManualMode(false);
+		enyo.webos.keyboard.setManualMode(false);
 		document.body.removeChild(this._clipboardTextArea);
 	},
 
@@ -315,14 +315,14 @@ webos = {
 		}
 		document.body.appendChild(this._clipboardTextArea);
 		this._clipboardTextArea.value = "";
-		enyo.webos.setManualMode(true); //suspend keyboard
+		enyo.webos.keyboard.setManualMode(true); //suspend keyboard
 		this._clipboardTextArea.select();
 		this._clipboardTextArea.oninput = function () {
 			inCallback(this._clipboardTextArea.value);
 			// "hide the textarea until it is needed again.
 			this._clipboardTextArea.value = "";
 			this._clipboardTextArea.blur();
-			enyo.webos.setManualMode(false);
+			enyo.webos.keyboard.setManualMode(false);
 			document.body.removeChild(this._clipboardTextArea);
 		}.bind(this);
 

--- a/source/webos.js
+++ b/source/webos.js
@@ -290,15 +290,6 @@ webos = {
 	},
 
 	/**
-		Pastes text from the system clipboard into the control which is currently focused.
-	 */
-	paste: function () {
-		if (window.PalmSystem) {
-			window.PalmSystem.paste();
-		}
-	},
-
-	/**
 		Copies inText to system clipboard
 	 */
 	setClipboard: function (inText) {


### PR DESCRIPTION
paste method was a duplicate of pasteClipboard and just recently introduced
(by me, because I didn't see the other one) in this commit:
https://github.com/webOS-ports/webos-lib/commit/2256b15ef9a03b21abb07cd161f0f0c7087abb80
So it is likely that no one used it, yet.

In the other clipboard methods the setManualMode method is in webos.keyboard, not in webos itself
(which is defined in Keyboard.js).